### PR TITLE
Reduce DOM elements rendered; single-pass over the original data

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "browser-sync": "^2.8.2",
     "chai": "^3.3.0",
     "chai-things": "^0.2.0",
+    "coffee-script": "^1.10.0",
     "connect-livereload": "^0.5.3",
     "del": "^1.2.1",
     "gulp": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -28,19 +28,23 @@
   },
   "devDependencies": {
     "browser-sync": "^2.8.2",
+    "chai": "^3.3.0",
+    "chai-things": "^0.2.0",
     "connect-livereload": "^0.5.3",
     "del": "^1.2.1",
     "gulp": "^3.9.0",
     "gulp-cached": "^1.1.0",
     "gulp-changed": "^1.3.0",
     "gulp-coffee": "^2.3.1",
-    "gulp-sass": "^2.0.4",
     "gulp-concat": "^2.6.0",
     "gulp-livereload": "^3.8.0",
     "gulp-newer": "^0.5.1",
     "gulp-remember": "^0.3.0",
+    "gulp-sass": "^2.0.4",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.4.0",
+    "gulp-util": "^3.0.6",
+    "mocha": "^2.3.3",
     "reload": "^0.4.0"
   }
 }

--- a/src/d3-flame-graph.coffee
+++ b/src/d3-flame-graph.coffee
@@ -85,7 +85,9 @@ d3.flameGraph = ->
       data = augment(data)
       console.timeEnd('augment')
       @original = data if not @original
+      console.time('partition')
       @_data = partitionData(data)
+      console.timeEnd('partition')
       @
 
     zoom: (node) ->
@@ -146,7 +148,7 @@ d3.flameGraph = ->
       containers = @container
         .selectAll('.node')
         .data(@data().filter((d) =>
-          @x(d.dx) > 0.1 and @y(d.y) >= 0 and not d.filler))
+          @x(d.dx) > 0.4 and @y(d.y) >= 0 and not d.filler))
         .enter()
           .append('g').attr('class', (d, idx) -> if idx == 0 then 'root node' else 'node')
 
@@ -158,6 +160,7 @@ d3.flameGraph = ->
         text: (d) => @label(d) if d.name and @x(d.dx) > 40
 
       console.timeEnd('render')
+      console.log("Processed #{@data().length} items")
       console.log("Rendered #{@container.selectAll('.node')[0]?.length} elements")
       @_renderAncestors()._enableNavigation()   if @zoomEnabled()
       @_renderTooltip()                         if @tooltip()
@@ -178,14 +181,6 @@ d3.flameGraph = ->
         .attr('y', (d, idx) => attrs.y(d, idx) + @cellHeight() / 2)
         .style('font-size', "#{@fontSize}em")
         .text(attrs.text)
-      # overlaying a transparent rectangle to capture events
-      # TODO: maybe there's a smarter way to do this?
-      containers.append('rect')
-        .attr('class', 'overlay')
-        .attr('width', attrs.width)
-        .attr('height', @cellHeight())
-        .attr('x', attrs.x)
-        .attr('y', attrs.y)
       @
 
     _renderTooltip: () ->

--- a/test/augment.coffee
+++ b/test/augment.coffee
@@ -1,0 +1,68 @@
+require('coffee-script/register');
+path    = require('path')
+exec    = require('child_process').exec
+d3      = require('d3')
+chai    = require('chai')
+expect  = chai.expect
+chai.use(require('chai-things'))
+
+# the flame graph plugin does not have an exporter
+# as it augments the existing d3 object
+require('../src/d3-flame-graph')
+
+# shut up the timer, does not make sense here
+console.time = ->
+console.timeEnd = ->
+
+describe 'augment nodes', ->
+  flameGraph = undefined
+  root = undefined
+  describe 'when provided with a simple tree', ->
+    beforeEach (done) ->
+      data = { value: 45, name:"root", children: [] }
+      data.children.push({name: "c1", value: 10}, {name: "c2", value: 20})
+      flameGraph = d3.flameGraph().data(data)
+      root = flameGraph.original # TODO: depending on this field is hacky
+      done()
+
+    it 'should mark the root as augmented', ->
+      expect(root.augmented).to.be.true
+
+    it 'should mark all the children as augmented', ->
+      expect(root.children).to.all.have.property('augmented', true)
+
+    it 'augments them with filler nodes', ->
+      expect(root.children).to.have.length(3)
+      filler = root.children[2]
+      expect(filler).has.property('filler', true)
+      expect(filler).has.property('value', 15)
+
+    it 'augments them with their level', ->
+      expect(root).has.property('level', 2)
+      expect(root.children).to.all.have.property('level', 1)
+
+    it 'augments them with their parents', ->
+
+    it 'saves the original value in a separate field', ->
+
+  describe 'when provided with a multilevel tree', ->
+    beforeEach (done) ->
+      data = { value: 45, name:"root", children: [] }
+      firstChild = {name: "c11", value: 10, children: [{name: "c21", value: 1}]}
+      secondChild = {name: "c12", value: 20}
+      data.children.push(firstChild, secondChild)
+      flameGraph = d3.flameGraph().data(data)
+      root = flameGraph.original
+      done()
+
+    it 'augments the root with the correct level', ->
+      expect(root).has.property('level', 3)
+
+    it 'augments the children with the correct level', ->
+      expect(root.children).to.include.an.item.that.has.property('level', 2)
+      expect(root.children).to.include.an.item.that.has.property('level', 1)
+
+    it 'augments the grandchildren with the correct level', ->
+      grandchildren = root.children[0].children
+      expect(grandchildren).to.all.have.property('level', 1)
+

--- a/test/sample.coffee
+++ b/test/sample.coffee
@@ -1,9 +1,0 @@
-path    = require('path')
-exec    = require('child_process').exec
-
-describe 'd3-flame-graph', ->
-  describe 'when instantiating a flame graph', ->
-
-    # TODO: figure out how to test installing dependencies
-    it 'does not do anything weird', ->
-


### PR DESCRIPTION
Improve performance by doing a one-pass traversal of the original data and reducing the number of DOM elements that are rendered - minimum width treshold was increased

Fixes #38, improves on #20, #37.
